### PR TITLE
Support for constructing caches using an existing db instead of a filepath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 test/memoize-cache/
 test/simple-cache/
 test/value-cache/
+test/alternative-cache/

--- a/lib/memoize-cache.js
+++ b/lib/memoize-cache.js
@@ -5,11 +5,21 @@ var levelup = require('levelup');
 
 // Memoizes an asynchronous function to a db of the given name
 // Based on the memoize function from caolan/async
-module.exports = function (path, fn, hashFn) {
-  var db = levelup(path, {
-    keyEncoding: 'binary',
-    valueEncoding: 'binary'
-  });
+module.exports = function (pathOrDb, fn, hashFn) {
+  var db;
+
+  if (typeof pathOrDb === 'string') {
+    db = levelup(pathOrDb, {
+      keyEncoding: 'binary',
+      valueEncoding: 'binary'
+    });
+  }
+  else if (typeof pathOrDb === 'object') {
+    db = pathOrDb;
+  }
+  else {
+    throw new Error('memoize-cache ctor param is not a string or object.');
+  }
 
   var queues = {};
 

--- a/lib/memoize-cache.js
+++ b/lib/memoize-cache.js
@@ -34,7 +34,7 @@ module.exports = function (pathOrDb, fn, hashFn) {
 
     db.get(key, function (err, value) {
       if (!err) {
-        console.log('Using memoized value:', value);
+        // console.log('Using memoized value:', value);
         return callback.apply(null, JSON.parse(value));
       }
 

--- a/lib/memoize-cache.js
+++ b/lib/memoize-cache.js
@@ -34,6 +34,7 @@ module.exports = function (pathOrDb, fn, hashFn) {
 
     db.get(key, function (err, value) {
       if (!err) {
+        console.log('Using memoized value:', value);
         return callback.apply(null, JSON.parse(value));
       }
 

--- a/lib/simple-cache.js
+++ b/lib/simple-cache.js
@@ -2,8 +2,16 @@
 
 var levelup = require('levelup');
 
-module.exports = function (path) {
-  this.db = levelup(path);
+module.exports = function (pathOrDb) {
+  if (typeof pathOrDb === 'string') {
+    this.db = levelup(pathOrDb);
+  }
+  else if (typeof pathOrDb === 'object') {
+    this.db = pathOrDb;
+  }
+  else {
+    throw new Error('simple-cache ctor param is not a string or object.');
+  }
 
   this.close = this.db.close.bind(this.db);
 

--- a/lib/value-cache.js
+++ b/lib/value-cache.js
@@ -5,8 +5,16 @@ var bytewise = require('bytewise');
 var levelup = require('levelup');
 var timestamp = require('monotonic-timestamp');
 
-var ValueCache = module.exports = function (path) {
-  this.db = levelup(path, {valueEncoding: 'binary'});
+var ValueCache = module.exports = function (pathOrDb) {
+  if (typeof pathOrDb === 'string') {
+    this.db = levelup(pathOrDb, {valueEncoding: 'binary'});
+  }
+  else if (typeof pathOrDb === 'object') {
+    this.db = pathOrDb;
+  }
+  else {
+    throw new Error('value-cache ctor param is not a string or object.');
+  }
 };
 
 ValueCache.prototype.close = function (cb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "level-cache-tools",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Cache tools backed by leveldb",
   "main": "level-cache-tools.js",
   "scripts": {

--- a/test/memoize-cache.js
+++ b/test/memoize-cache.js
@@ -4,6 +4,7 @@ var async = require('async');
 var path = require('path');
 var should = require('chai').should();
 var rimraf = require('rimraf');
+var levelup = require('levelup');
 
 var MemoizeCache = require('..').MemoizeCache;
 
@@ -46,4 +47,18 @@ describe('MemoizeCache', function () {
       });
     });
   });
+
+  describe('Construct with db', function dbCtorSuite() {
+    var altCachePath = path.join(__dirname, 'alternative-cache');
+
+    before(function cleanUp() {
+      rimraf.sync(altCachePath);
+    });
+
+    it('should create a memoized function using the DB.', function dbCtor() {
+      var db = levelup(path.join(__dirname, 'alternative-cache'));
+      var memoizedFn = new MemoizeCache(db, asyncFn);
+      memoizedFn.should.be.a('function');
+    });
+  });  
 });

--- a/test/simple-cache.js
+++ b/test/simple-cache.js
@@ -4,6 +4,7 @@ require('chai').should();
 
 var path = require('path');
 var rimraf = require('rimraf');
+var levelup = require('levelup');
 
 var SimpleCache = require('..').SimpleCache;
 
@@ -31,6 +32,22 @@ describe('SimpleCache', function () {
 
         cb();
       });
+    });
+  });
+
+  describe('Construct with db', function dbCtorSuite() {
+    var altCachePath = path.join(__dirname, 'alternative-cache');
+
+    before(function cleanUp() {
+      rimraf.sync(altCachePath);
+    });
+
+    it('should create a cache using the provided DB.', function dbCtor() {
+      var db = levelup(altCachePath);
+      var dbCache = new SimpleCache(db);
+      dbCache.should.be.an('object');
+      dbCache.get.should.be.a('function');
+      dbCache.put.should.be.a('function');
     });
   });
 });

--- a/test/value-cache.js
+++ b/test/value-cache.js
@@ -5,6 +5,7 @@ require('chai').should();
 var path = require('path');
 var rimraf = require('rimraf');
 var ValueCache = require('..').ValueCache;
+var levelup = require('levelup');
 
 var PATH = path.join(__dirname, 'value-cache');
 
@@ -42,6 +43,23 @@ describe('ValueCache', function () {
           });
         });
       });
+    });
+  });
+
+  describe('Construct with db', function dbCtorSuite() {
+    var altCachePath = path.join(__dirname, 'alternative-cache');
+
+    before(function cleanUp() {
+      rimraf.sync(altCachePath);
+    });
+
+    it('should create a value cache using the DB.', function dbCtor() {
+      var db = levelup(path.join(__dirname, 'alternative-cache'));
+      var strings = new ValueCache(db);
+      strings.should.be.an('object');
+      strings.contains.should.be.a('function');
+      strings.put.should.be.a('function');
+      db.close();
     });
   });
 });


### PR DESCRIPTION
These changes make each constructor check the type of the first parameter. If it's a string, it assumes it's a file path and continues as it used to and creates a DB using that. However, if it's a object, it will treat it like and already existing DB and just use that.

The reason for this change is so that multiple caches can share the same db. This way, if you're memoizing ten functions, you don't have to have ten db files. Similarly, if you want to use those functions through `multilevel`, you don't have to have ten RPC servers to talk to.

If you're cool with this, I think that adding support for using namespaces via `sublevel` would be helpful for sharing a db file among different caches.
